### PR TITLE
fix: avoid raising duplicate style violations from pages and artboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sketch-hq/sketch-lint-ruleset-core",
   "description": "The core sketch-lint ruleset",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "license": "MIT",
   "repository": "github:sketch-hq/sketch-lint-ruleset-core",
   "types": "dist/cjs/index",

--- a/src/styles-no-duplicate/styles-no-duplicate.ts
+++ b/src/styles-no-duplicate/styles-no-duplicate.ts
@@ -15,6 +15,9 @@ const rule: Rule = async (context: RuleInvocationContext): Promise<void> => {
   await utils.walk({
     $layers(node): void {
       const layer = utils.nodeToObject(node)
+      // Despite having style props in the file format, artboard and page styles
+      // are not user editable via the inspector so ignore them
+      if (layer._class === 'artboard' || layer._class === 'page') return
       if (!('style' in layer)) return // Narrow type to layers with a `style` prop
       if (!layer.style) return // Narrow type to truthy `style` prop
       if (typeof layer.sharedStyleID === 'string') return // Ignore layers using a shared style


### PR DESCRIPTION
Refs https://github.com/sketch-hq/Sketch/issues/27928

This was due to artboards and pages being created with identical/default `style` props when added to the canvas. As far as I can see though these are neither used, nor editable via the inspector, so it doesn't make sense to check their `style` prop when scanning for duplicate layer styles.