### PR TITLE
Use cache iterators api

### DIFF
--- a/.changeset/stupid-timers-press.md
+++ b/.changeset/stupid-timers-press.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-assistant-core-rules': minor
+---
+
+Use cache iteration api

--- a/src/rules/artboards-grid/index.ts
+++ b/src/rules/artboards-grid/index.ts
@@ -22,6 +22,7 @@ export const createRule: CreateRuleFunction = (i18n) => {
     const grids = utils.getOption('grids')
     if (!Array.isArray(grids) || grids.length === 0) return
     const specs: GridSpec[] = []
+
     for (let i = 0; i < grids.length; i++) {
       const grid = grids[i]
       if (typeof grid !== 'object') continue
@@ -30,26 +31,24 @@ export const createRule: CreateRuleFunction = (i18n) => {
         specs.push({ gridBlockSize, thickLinesEvery })
       }
     }
-    await utils.iterateCache({
-      async artboard(node): Promise<void> {
-        const { grid } = utils.nodeToObject<FileFormat.Artboard>(node)
-        if (!grid) {
-          invalid.push(node) // Treat artboards without grid settings as invalid
-          return
-        }
-        // The artboard's grid much precisely match one of the grids defined in the
-        // options
-        const gridValid = specs
-          .map(
-            (spec) =>
-              grid.gridSize === spec.gridBlockSize && grid.thickGridTimes === spec.thickLinesEvery,
-          )
-          .includes(true)
-        if (!gridValid) {
-          invalid.push(node)
-        }
-      },
-    })
+    for (const node of utils.iterators.artboard) {
+      const { grid } = utils.nodeToObject<FileFormat.Artboard>(node)
+      if (!grid) {
+        invalid.push(node) // Treat artboards without grid settings as invalid
+        return
+      }
+      // The artboard grid much precisely match one of the grids defined in the
+      // options
+      const gridValid = specs
+        .map(
+          (spec) =>
+            grid.gridSize === spec.gridBlockSize && grid.thickGridTimes === spec.thickLinesEvery,
+        )
+        .includes(true)
+      if (!gridValid) {
+        invalid.push(node)
+      }
+    }
     utils.report(
       invalid.map(
         (node): ReportItem => ({

--- a/src/rules/artboards-layout/index.ts
+++ b/src/rules/artboards-layout/index.ts
@@ -83,54 +83,52 @@ export const createRule: CreateRuleFunction = (i18n) => {
       }
       specs.push(spec)
     }
-    await utils.iterateCache({
-      async artboard(node): Promise<void> {
-        const { layout } = utils.nodeToObject<FileFormat.Artboard>(node)
-        if (!layout || !layout.isEnabled) {
-          invalid.push(node) // Treat artboards without grid settings as invalid
-          return
-        }
-        // The artboard's layout much match one of the layouts defined in the options
-        const columnsValid = specs
-          .map((spec) => {
-            if (spec.drawVertical === false) {
-              // Treat artboard columns as valid and return early if
-              // drawVertical set to false, i.e. columns checkbox in layout
-              // UI unchecked.
-              return true
-            }
-            return (
-              typeof spec.columns === 'object' &&
-              spec.columns.gutterWidth === layout.gutterWidth &&
-              spec.columns.columnWidth === layout.columnWidth &&
-              spec.columns.guttersOutside === layout.guttersOutside &&
-              spec.columns.horizontalOffset === layout.horizontalOffset &&
-              spec.columns.numberOfColumns === layout.numberOfColumns &&
-              spec.columns.totalWidth === layout.totalWidth
-            )
-          })
-          .includes(true)
-        const rowsValid = specs
-          .map((spec) => {
-            if (spec.drawHorizontal === false) {
-              // Treat artboard rows as valid and return early if
-              // drawHorizontal set to false, i.e. rows checkbox in layout
-              // UI unchecked.
-              return true
-            }
-            return (
-              typeof spec.rows === 'object' &&
-              spec.rows.gutterHeight === layout.gutterHeight &&
-              spec.rows.rowHeightMultiplication === layout.rowHeightMultiplication &&
-              spec.rows.drawHorizontalLines === layout.drawHorizontalLines
-            )
-          })
-          .includes(true)
-        if (!rowsValid || !columnsValid) {
-          invalid.push(node)
-        }
-      },
-    })
+    for (const node of utils.iterators.artboard) {
+      const { layout } = utils.nodeToObject<FileFormat.Artboard>(node)
+      if (!layout || !layout.isEnabled) {
+        invalid.push(node) // Treat artboards without grid settings as invalid
+        continue
+      }
+      // The artboard's layout much match one of the layouts defined in the options
+      const columnsValid = specs
+        .map((spec) => {
+          if (spec.drawVertical === false) {
+            // Treat artboard columns as valid and return early if
+            // drawVertical set to false, i.e. columns checkbox in layout
+            // UI unchecked.
+            return true
+          }
+          return (
+            typeof spec.columns === 'object' &&
+            spec.columns.gutterWidth === layout.gutterWidth &&
+            spec.columns.columnWidth === layout.columnWidth &&
+            spec.columns.guttersOutside === layout.guttersOutside &&
+            spec.columns.horizontalOffset === layout.horizontalOffset &&
+            spec.columns.numberOfColumns === layout.numberOfColumns &&
+            spec.columns.totalWidth === layout.totalWidth
+          )
+        })
+        .includes(true)
+      const rowsValid = specs
+        .map((spec) => {
+          if (spec.drawHorizontal === false) {
+            // Treat artboard rows as valid and return early if
+            // drawHorizontal set to false, i.e. rows checkbox in layout
+            // UI unchecked.
+            return true
+          }
+          return (
+            typeof spec.rows === 'object' &&
+            spec.rows.gutterHeight === layout.gutterHeight &&
+            spec.rows.rowHeightMultiplication === layout.rowHeightMultiplication &&
+            spec.rows.drawHorizontalLines === layout.drawHorizontalLines
+          )
+        })
+        .includes(true)
+      if (!rowsValid || !columnsValid) {
+        invalid.push(node)
+      }
+    }
     utils.report(
       invalid.map(
         (node): ReportItem => ({

--- a/src/rules/artboards-max-ungrouped-layers/index.ts
+++ b/src/rules/artboards-max-ungrouped-layers/index.ts
@@ -12,24 +12,22 @@ export const createRule: CreateRuleFunction = (i18n) => {
     const { utils } = context
     const maxUngroupedLayers = utils.getOption('maxUngroupedLayers')
     assertMaxUngrouped(maxUngroupedLayers)
-    await utils.iterateCache({
-      async artboard(node): Promise<void> {
-        const artboard = utils.nodeToObject<FileFormat.Artboard>(node)
-        const nonGroupLayers = artboard.layers.filter((layer) => layer._class !== 'group').length
-        if (nonGroupLayers > maxUngroupedLayers) {
-          utils.report({
-            node,
-            message: i18n._(
-              plural({
-                value: nonGroupLayers,
-                one: `There is one ungrouped layer within this Artboard`,
-                other: `There are # ungrouped layers within this Artboard`,
-              }),
-            ),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.artboard) {
+      const artboard = utils.nodeToObject<FileFormat.Artboard>(node)
+      const nonGroupLayers = artboard.layers.filter((layer) => layer._class !== 'group').length
+      if (nonGroupLayers > maxUngroupedLayers) {
+        utils.report({
+          node,
+          message: i18n._(
+            plural({
+              value: nonGroupLayers,
+              one: `There is one ungrouped layer within this Artboard`,
+              other: `There are # ungrouped layers within this Artboard`,
+            }),
+          ),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/borders-no-disabled/index.ts
+++ b/src/rules/borders-no-disabled/index.ts
@@ -13,30 +13,28 @@ const styleHasDisabledBorder = (style: FileFormat.Style): boolean => {
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node: Node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (isCombinedShapeChildLayer(node, utils)) return // Ignore layers in combined shapes
-        if (!('style' in layer)) return // Narrow type to layers with a `style` prop
-        if (!layer.style) return // Narrow type to truthy `style` prop
-        if (typeof layer.sharedStyleID === 'string') return // Ignore layers using a shared style
-        if (styleHasDisabledBorder(layer.style)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled border in this layer style`),
-          })
-        }
-      },
-      async sharedStyle(node: Node): Promise<void> {
-        const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
-        if (styleHasDisabledBorder(sharedStyle.value)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled border in this shared style`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (isCombinedShapeChildLayer(node, utils)) continue // Ignore layers in combined shapes
+      if (!('style' in layer)) continue // Narrow type to layers with a `style` prop
+      if (!layer.style) continue // Narrow type to truthy `style` prop
+      if (typeof layer.sharedStyleID === 'string') continue // Ignore layers using a shared style
+      if (styleHasDisabledBorder(layer.style)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled border in this layer style`),
+        })
+      }
+    }
+    for (const node of utils.iterators.sharedStyle) {
+      const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
+      if (styleHasDisabledBorder(sharedStyle.value)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled border in this shared style`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/exported-layers-normal-blend-mode/index.ts
+++ b/src/rules/exported-layers-normal-blend-mode/index.ts
@@ -12,35 +12,33 @@ const isBlended = (
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (layer._class === 'artboard' || layer._class === 'page') return
-        if (layer.exportOptions.exportFormats.length === 0) return
-        if (layer.style?.contextSettings?.blendMode !== FileFormat.BlendMode.Normal) {
-          utils.report({
-            node,
-            message: i18n._(
-              t`Blend mode found on exported layer, consider flattening the blend mode for consistent export results.`,
-            ),
-          })
-          return
-        }
-        if (
-          isBlended(layer.style?.fills) ||
-          isBlended(layer.style?.borders) ||
-          isBlended(layer.style?.shadows) ||
-          isBlended(layer.style?.innerShadows)
-        ) {
-          utils.report({
-            node,
-            message: i18n._(
-              t`Blend mode found on exported layer, consider flattening the blend modes for consistent export results.`,
-            ),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (layer._class === 'artboard' || layer._class === 'page') continue
+      if (layer.exportOptions.exportFormats.length === 0) continue
+      if (layer.style?.contextSettings?.blendMode !== FileFormat.BlendMode.Normal) {
+        utils.report({
+          node,
+          message: i18n._(
+            t`Blend mode found on exported layer, consider flattening the blend mode for consistent export results.`,
+          ),
+        })
+        continue
+      }
+      if (
+        isBlended(layer.style?.fills) ||
+        isBlended(layer.style?.borders) ||
+        isBlended(layer.style?.shadows) ||
+        isBlended(layer.style?.innerShadows)
+      ) {
+        utils.report({
+          node,
+          message: i18n._(
+            t`Blend mode found on exported layer, consider flattening the blend modes for consistent export results.`,
+          ),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/fills-no-disabled/index.ts
+++ b/src/rules/fills-no-disabled/index.ts
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { RuleContext, RuleFunction, Node, FileFormat } from '@sketch-hq/sketch-assistant-types'
+import { RuleContext, RuleFunction, FileFormat } from '@sketch-hq/sketch-assistant-types'
 
 import { CreateRuleFunction } from '../..'
 import { isCombinedShapeChildLayer } from '../../rule-helpers'
@@ -10,30 +10,28 @@ const styleHasDisabledFill = (style: FileFormat.Style): boolean =>
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node: Node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (isCombinedShapeChildLayer(node, utils)) return // Ignore layers in combined shapes
-        if (!('style' in layer)) return // Narrow type to layers with a `style` prop
-        if (!layer.style) return // Narrow type to truthy `style` prop
-        if (typeof layer.sharedStyleID === 'string') return // Ignore layers using a shared style
-        if (styleHasDisabledFill(layer.style)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled fill in this layer style`),
-          })
-        }
-      },
-      async sharedStyle(node: Node): Promise<void> {
-        const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
-        if (styleHasDisabledFill(sharedStyle.value)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled fill in this shared style`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (isCombinedShapeChildLayer(node, utils)) continue // Ignore layers in combined shapes
+      if (!('style' in layer)) continue // Narrow type to layers with a `style` prop
+      if (!layer.style) continue // Narrow type to truthy `style` prop
+      if (typeof layer.sharedStyleID === 'string') continue // Ignore layers using a shared style
+      if (styleHasDisabledFill(layer.style)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled fill in this layer style`),
+        })
+      }
+    }
+    for (const node of utils.iterators.sharedStyle) {
+      const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
+      if (styleHasDisabledFill(sharedStyle.value)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled fill in this shared style`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/groups-max-layers/index.ts
+++ b/src/rules/groups-max-layers/index.ts
@@ -24,25 +24,23 @@ export const createRule: CreateRuleFunction = (i18n) => {
     assertMaxLayers(maxLayers)
     assertSkipClasses(skipClasses)
 
-    await utils.iterateCache({
-      async $groups(node): Promise<void> {
-        const group = utils.nodeToObject<FileFormat.AnyGroup>(node)
-        if (group._class === 'shapeGroup') return // Do not consider shape groups, its common/expected for these to have many layers
-        const numLayers = group.layers.filter((layer) => !skipClasses.includes(layer._class)).length
-        if (numLayers > maxLayers) {
-          utils.report({
-            node,
-            message: i18n._(
-              plural({
-                value: numLayers,
-                one: 'There is one layer in this group',
-                other: 'There are # layers in this group',
-              }),
-            ),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$groups) {
+      const group = utils.nodeToObject<FileFormat.AnyGroup>(node)
+      if (group._class === 'shapeGroup') continue // Do not consider shape groups, its common/expected for these to have many layers
+      const numLayers = group.layers.filter((layer) => !skipClasses.includes(layer._class)).length
+      if (numLayers > maxLayers) {
+        utils.report({
+          node,
+          message: i18n._(
+            plural({
+              value: numLayers,
+              one: 'There is one layer in this group',
+              other: 'There are # layers in this group',
+            }),
+          ),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/groups-no-empty/index.ts
+++ b/src/rules/groups-no-empty/index.ts
@@ -6,17 +6,15 @@ import { CreateRuleFunction } from '../..'
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async group(node): Promise<void> {
-        const group = utils.nodeToObject<FileFormat.Group>(node)
-        if (group.layers.length === 0) {
-          utils.report({
-            node,
-            message: i18n._(t`This group is empty`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.group) {
+      const group = utils.nodeToObject<FileFormat.Group>(node)
+      if (group.layers.length === 0) {
+        utils.report({
+          node,
+          message: i18n._(t`This group is empty`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/groups-no-redundant/index.ts
+++ b/src/rules/groups-no-redundant/index.ts
@@ -6,21 +6,19 @@ import { CreateRuleFunction } from '../..'
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async group(node): Promise<void> {
-        const group = utils.nodeToObject<FileFormat.Group>(node)
-        const usesSharedStyle = typeof group.sharedStyleID === 'string'
-        const isStyled = group.style && group.style.shadows && group.style.shadows.length > 0
-        const hasOneChild = group.layers.length === 1
-        const onlyChildIsGroup = hasOneChild && group.layers[0]._class === 'group'
-        if (!usesSharedStyle && !isStyled && hasOneChild && onlyChildIsGroup) {
-          utils.report({
-            node,
-            message: i18n._(t`This group is redundant`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.group) {
+      const group = utils.nodeToObject<FileFormat.Group>(node)
+      const usesSharedStyle = typeof group.sharedStyleID === 'string'
+      const isStyled = group.style && group.style.shadows && group.style.shadows.length > 0
+      const hasOneChild = group.layers.length === 1
+      const onlyChildIsGroup = hasOneChild && group.layers[0]._class === 'group'
+      if (!usesSharedStyle && !isStyled && hasOneChild && onlyChildIsGroup) {
+        utils.report({
+          node,
+          message: i18n._(t`This group is redundant`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/groups-no-similar/index.ts
+++ b/src/rules/groups-no-similar/index.ts
@@ -18,18 +18,16 @@ export const createRule: CreateRuleFunction = (i18n) => {
     const maxIdentical = utils.getOption('maxIdentical')
     assertMaxIdentical(maxIdentical)
     const fingerprints = new Map<GroupFingerprint, GroupNode[]>()
-    await utils.iterateCache({
-      async group(node): Promise<void> {
-        const group = utils.nodeToObject<FileFormat.Group>(node)
-        const numberOfLayers = group.layers.length
-        const layerTypes = group.layers.map((layer) => layer?._class)
-        const layerNames = group.layers.map((layer) => layer?.name)
-        const fingerprint = JSON.stringify({ numberOfLayers, layerTypes, layerNames })
-        const similarGroups = fingerprints.get(fingerprint) || []
-        similarGroups.push(node as GroupNode)
-        fingerprints.set(fingerprint, similarGroups)
-      },
-    })
+    for (const node of utils.iterators.group) {
+      const group = utils.nodeToObject<FileFormat.Group>(node)
+      const numberOfLayers = group.layers.length
+      const layerTypes = group.layers.map((layer) => layer?._class)
+      const layerNames = group.layers.map((layer) => layer?.name)
+      const fingerprint = JSON.stringify({ numberOfLayers, layerTypes, layerNames })
+      const similarGroups = fingerprints.get(fingerprint) || []
+      similarGroups.push(node as GroupNode)
+      fingerprints.set(fingerprint, similarGroups)
+    }
     for (let similar of fingerprints.values()) {
       if (similar.length > maxIdentical) {
         similar.forEach((node) => {

--- a/src/rules/images-no-outsized/index.ts
+++ b/src/rules/images-no-outsized/index.ts
@@ -25,12 +25,9 @@ export const createRule: CreateRuleFunction = (i18n) => {
 
     const imageProcessor = createImageProcessor(utils.getImageMetadata, utils.nodeToObject)
 
-    await utils.iterateCache({
-      async $layers(node): Promise<void> {
-        imageProcessor.handleLayerImages(node)
-      },
-    })
-
+    for (const node of utils.iterators.$layers) {
+      imageProcessor.handleLayerImages(node)
+    }
     const results = await imageProcessor.getResults()
 
     for (const usages of results.values()) {

--- a/src/rules/images-no-undersized/index.ts
+++ b/src/rules/images-no-undersized/index.ts
@@ -25,11 +25,9 @@ export const createRule: CreateRuleFunction = (i18n) => {
 
     const imageProcessor = createImageProcessor(utils.getImageMetadata, utils.nodeToObject)
 
-    await utils.iterateCache({
-      async $layers(node): Promise<void> {
-        imageProcessor.handleLayerImages(node)
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      imageProcessor.handleLayerImages(node)
+    }
 
     const results = await imageProcessor.getResults()
 

--- a/src/rules/inner-shadows-no-disabled/index.ts
+++ b/src/rules/inner-shadows-no-disabled/index.ts
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { RuleContext, RuleFunction, Node, FileFormat } from '@sketch-hq/sketch-assistant-types'
+import { RuleContext, RuleFunction, FileFormat } from '@sketch-hq/sketch-assistant-types'
 
 import { CreateRuleFunction } from '../..'
 import { isCombinedShapeChildLayer } from '../../rule-helpers'
@@ -10,31 +10,29 @@ const styleHasDisabledInnerShadows = (style: FileFormat.Style): boolean =>
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node: Node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (isCombinedShapeChildLayer(node, utils)) return // Ignore layers in combined shapes
-        if (!('style' in layer)) return // Narrow type to layers with a `style` prop
-        if (!layer.style) return // Narrow type to truthy `style` prop
-        if (typeof layer.sharedStyleID === 'string') return // Ignore layers using a shared style
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (isCombinedShapeChildLayer(node, utils)) continue // Ignore layers in combined shapes
+      if (!('style' in layer)) continue // Narrow type to layers with a `style` prop
+      if (!layer.style) continue // Narrow type to truthy `style` prop
+      if (typeof layer.sharedStyleID === 'string') continue // Ignore layers using a shared style
 
-        if (styleHasDisabledInnerShadows(layer.style)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled inner shadow in this layer style`),
-          })
-        }
-      },
-      async sharedStyle(node: Node): Promise<void> {
-        const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
-        if (styleHasDisabledInnerShadows(sharedStyle.value)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled inner shadow in this shared style`),
-          })
-        }
-      },
-    })
+      if (styleHasDisabledInnerShadows(layer.style)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled inner shadow in this layer style`),
+        })
+      }
+    }
+    for (const node of utils.iterators.sharedStyle) {
+      const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
+      if (styleHasDisabledInnerShadows(sharedStyle.value)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled inner shadow in this shared style`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/layer-styles-prefer-library/index.ts
+++ b/src/rules/layer-styles-prefer-library/index.ts
@@ -19,59 +19,57 @@ export const createRule: CreateRuleFunction = (i18n) => {
       new Map(),
     )
     // Reports are done in place, while iterating through cache.
-    await utils.iterateCache({
-      async $layers(node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (IGNORE_CLASSES.includes(node._class)) return
-        if (isCombinedShapeChildLayer(node, utils)) return // Ignore layers in combined shapes
-        if (layer._class === 'group' && !layer.style?.shadows?.length) return // Ignore groups with default styles (i.e. no shadows)
-        if (typeof layer.sharedStyleID !== 'string') {
-          // Report immediately if there is no sharedStyleID
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (IGNORE_CLASSES.includes(node._class)) continue
+      if (isCombinedShapeChildLayer(node, utils)) continue // Ignore layers in combined shapes
+      if (layer._class === 'group' && !layer.style?.shadows?.length) continue // Ignore groups with default styles (i.e. no shadows)
+      if (typeof layer.sharedStyleID !== 'string') {
+        // Report immediately if there is no sharedStyleID
+        utils.report([
+          {
+            node,
+            message: i18n._(t`Layer styles must be set with the shared styles of a library`),
+          },
+        ])
+        continue // don't process this node further
+      }
+      const library = libraries.get(layer.sharedStyleID)
+      if (!library) {
+        // sharedStyleID does not belong to a library
+        utils.report([
+          {
+            node,
+            message: i18n._(t`A shared style from a library is expected`),
+          },
+        ])
+        continue
+      }
+      const libraryName = library.sourceLibraryName
+      // Determine if the library is one of the allowed libraries
+      if (Array.isArray(authorizedLibraries) && authorizedLibraries.length > 0) {
+        const isAuthorized = authorizedLibraries.indexOf(libraryName) > -1
+        if (!isAuthorized) {
           utils.report([
             {
               node,
-              message: i18n._(t`Layer styles must be set with the shared styles of a library`),
+              message: i18n._(t`Uses the unauthorized library "${libraryName}"`),
             },
           ])
-          return // don't process this node further
+          continue
         }
-        const library = libraries.get(layer.sharedStyleID)
-        if (!library) {
-          // sharedStyleID does not belong to a library
-          utils.report([
-            {
-              node,
-              message: i18n._(t`A shared style from a library is expected`),
-            },
-          ])
-          return
-        }
-        const libraryName = library.sourceLibraryName
-        // Determine if the library is one of the allowed libraries
-        if (Array.isArray(authorizedLibraries) && authorizedLibraries.length > 0) {
-          const isAuthorized = authorizedLibraries.indexOf(libraryName) > -1
-          if (!isAuthorized) {
-            utils.report([
-              {
-                node,
-                message: i18n._(t`Uses the unauthorized library "${libraryName}"`),
-              },
-            ])
-            return
-          }
-        }
-        // Check if the layer styles differ from the library
-        const isStyleEq = utils.styleEq(layer.style, library.localSharedStyle.value)
-        if (!isStyleEq) {
-          utils.report([
-            {
-              node,
-              message: i18n._(t`Shared style differs from library`),
-            },
-          ])
-        }
-      },
-    })
+      }
+      // Check if the layer styles differ from the library
+      const isStyleEq = utils.styleEq(layer.style, library.localSharedStyle.value)
+      if (!isStyleEq) {
+        utils.report([
+          {
+            node,
+            message: i18n._(t`Shared style differs from library`),
+          },
+        ])
+      }
+    }
   }
 
   return {

--- a/src/rules/layers-no-hidden/index.ts
+++ b/src/rules/layers-no-hidden/index.ts
@@ -6,17 +6,15 @@ import { CreateRuleFunction } from '../..'
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (layer.isVisible === false) {
-          utils.report({
-            node,
-            message: i18n._(t`This layer is hidden`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (layer.isVisible === false) {
+        utils.report({
+          node,
+          message: i18n._(t`This layer is hidden`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/layers-no-loose/index.ts
+++ b/src/rules/layers-no-loose/index.ts
@@ -9,17 +9,15 @@ const isLooseLayer = (layer: FileFormat.AnyLayer) =>
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async page(node): Promise<void> {
-        const page = utils.nodeToObject<FileFormat.Page>(node)
-        if (page.layers.some(isLooseLayer)) {
-          utils.report({
-            node,
-            message: i18n._(t`This layer is not inside an Artboard`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.page) {
+      const page = utils.nodeToObject<FileFormat.Page>(node)
+      if (page.layers.some(isLooseLayer)) {
+        utils.report({
+          node,
+          message: i18n._(t`This layer is not inside an Artboard`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/shadows-no-disabled/index.ts
+++ b/src/rules/shadows-no-disabled/index.ts
@@ -10,30 +10,28 @@ const styleHasDisabledShadow = (style: FileFormat.Style): boolean =>
 export const createRule: CreateRuleFunction = (i18n) => {
   const rule: RuleFunction = async (context: RuleContext): Promise<void> => {
     const { utils } = context
-    await utils.iterateCache({
-      async $layers(node: Node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
-        if (isCombinedShapeChildLayer(node, utils)) return // Ignore layers in combined shapes
-        if (!('style' in layer)) return // Narrow type to layers with a `style` prop
-        if (!layer.style) return // Narrow type to truthy `style` prop
-        if (typeof layer.sharedStyleID === 'string') return // Ignore layers using a shared style
-        if (styleHasDisabledShadow(layer.style)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled shadow on this layer style`),
-          })
-        }
-      },
-      async sharedStyle(node: Node): Promise<void> {
-        const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
-        if (styleHasDisabledShadow(sharedStyle.value)) {
-          utils.report({
-            node,
-            message: i18n._(t`There's a disabled shadow on this shared style`),
-          })
-        }
-      },
-    })
+    for (const node of utils.iterators.$layers) {
+      const layer = utils.nodeToObject<FileFormat.AnyLayer>(node)
+      if (isCombinedShapeChildLayer(node, utils)) continue // Ignore layers in combined shapes
+      if (!('style' in layer)) continue // Narrow type to layers with a `style` prop
+      if (!layer.style) continue // Narrow type to truthy `style` prop
+      if (typeof layer.sharedStyleID === 'string') continue // Ignore layers using a shared style
+      if (styleHasDisabledShadow(layer.style)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled shadow on this layer style`),
+        })
+      }
+    }
+    for (const node of utils.iterators.sharedStyle) {
+      const sharedStyle = utils.nodeToObject<FileFormat.SharedStyle>(node)
+      if (styleHasDisabledShadow(sharedStyle.value)) {
+        utils.report({
+          node,
+          message: i18n._(t`There's a disabled shadow on this shared style`),
+        })
+      }
+    }
   }
 
   return {

--- a/src/rules/shared-styles-no-unused/index.ts
+++ b/src/rules/shared-styles-no-unused/index.ts
@@ -10,23 +10,21 @@ export const createRule: CreateRuleFunction = (i18n) => {
     const sharedStyles: Node<FileFormat.SharedStyle>[] = []
     const usages: Set<string> = new Set()
 
-    await utils.iterateCache({
-      async sharedStyle(node) {
-        sharedStyles.push(node as Node<FileFormat.SharedStyle>)
-      },
-      async symbolInstance(node) {
-        const obj = utils.nodeToObject<FileFormat.SymbolInstance>(node)
-        obj.overrideValues.forEach((override) => {
-          if (typeof override.value === 'string') usages.add(override.value)
-        })
-      },
-      async $layers(node) {
-        const obj = utils.nodeToObject(node)
-        if ('sharedStyleID' in obj && typeof obj.sharedStyleID === 'string') {
-          usages.add(obj.sharedStyleID)
-        }
-      },
-    })
+    for (const node of utils.iterators.sharedStyle) {
+      sharedStyles.push(node as Node<FileFormat.SharedStyle>)
+    }
+    for (const node of utils.iterators.symbolInstance) {
+      const obj = utils.nodeToObject<FileFormat.SymbolInstance>(node)
+      obj.overrideValues.forEach((override) => {
+        if (typeof override.value === 'string') usages.add(override.value)
+      })
+    }
+    for (const node of utils.iterators.$layers) {
+      const obj = utils.nodeToObject(node)
+      if ('sharedStyleID' in obj && typeof obj.sharedStyleID === 'string') {
+        usages.add(obj.sharedStyleID)
+      }
+    }
 
     const invalid: Node[] = sharedStyles.filter((node) => !usages.has(node.do_objectID))
 

--- a/src/rules/symbols-no-unused/index.ts
+++ b/src/rules/symbols-no-unused/index.ts
@@ -8,14 +8,12 @@ export const createRule: CreateRuleFunction = (i18n) => {
     const { utils } = context
     const masters: Node[] = []
     const instances: Node[] = []
-    await utils.iterateCache({
-      async symbolMaster(node): Promise<void> {
-        masters.push(node)
-      },
-      async symbolInstance(node): Promise<void> {
-        instances.push(node)
-      },
-    })
+    for (const node of utils.iterators.symbolMaster) {
+      masters.push(node)
+    }
+    for (const node of utils.iterators.symbolInstance) {
+      instances.push(node)
+    }
     const invalid: Node[] = masters.filter(
       (master) =>
         instances.findIndex(

--- a/src/rules/text-styles-no-dirty/index.ts
+++ b/src/rules/text-styles-no-dirty/index.ts
@@ -14,31 +14,28 @@ export const createRule: CreateRuleFunction = (i18n) => {
     // node iterator bellow
     const sharedStyles: Map<string, SharedStyle> = new Map()
 
-    await utils.iterateCache({
-      // Builds the shared styles container
-      async sharedStyle(node) {
-        const style: SharedStyle = node as SharedStyle
-        if (typeof style.do_objectID === 'string') {
-          sharedStyles.set(style.do_objectID, style)
-        }
-      },
-      async text(node): Promise<void> {
-        const layer = utils.nodeToObject<FileFormat.Text>(node)
-        if (typeof layer.sharedStyleID === 'string') {
-          // Get the shared style object
-          const sharedStyle = sharedStyles.get(layer.sharedStyleID)
-          if (sharedStyle) {
-            // Report if this text style differs from its shared style
-            if (!layer.style || !utils.textStyleEq(layer.style, sharedStyle.value)) {
-              utils.report({
-                node,
-                message: i18n._(t`This text style is different from its shared style`),
-              })
-            }
+    for (const node of utils.iterators.sharedStyle) {
+      const style: SharedStyle = node as SharedStyle
+      if (typeof style.do_objectID === 'string') {
+        sharedStyles.set(style.do_objectID, style)
+      }
+    }
+    for (const node of utils.iterators.text) {
+      const layer = utils.nodeToObject<FileFormat.Text>(node)
+      if (typeof layer.sharedStyleID === 'string') {
+        // Get the shared style object
+        const sharedStyle = sharedStyles.get(layer.sharedStyleID)
+        if (sharedStyle) {
+          // Report if this text style differs from its shared style
+          if (!layer.style || !utils.textStyleEq(layer.style, sharedStyle.value)) {
+            utils.report({
+              node,
+              message: i18n._(t`This text style is different from its shared style`),
+            })
           }
         }
-      },
-    })
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
Changes the usage of `iterateCache` to the new iterators api.

This refactor touches almost all rules, it consists of:
- Change the `iterateCache` with `for..of`
- Change the `return` in each of the iterated attributes with a `continue`

All unit tests pass. Though it is possible that something is not being covered and missed me.